### PR TITLE
Update the stop reading command to Ctrl

### DIFF
--- a/voiceover-helper.js
+++ b/voiceover-helper.js
@@ -54,7 +54,7 @@ $body.append(`
       </tr>
       <tr>
         <td class="voiceover-helper-command">
-          VO
+          Ctrl
         </td>
         <td class="voiceover-helper-help">
           stop reading


### PR DESCRIPTION
The command for stopping VoiceOver reading is Ctrl as far as I am aware. This is also how WebAIM document[1] the stop reading command.

1. https://webaim.org/articles/voiceover/